### PR TITLE
Add a script to consolidate OL author remote IDs with wikidata author remote IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 logs
 
+exports

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,3 @@
 venv/
 
 logs
-
-exports

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,8 @@ RUN if [ -n "$APT_MIRROR" ]; then \
         apt update; \
     fi && apt install -y \
         git \
-        expect
+        expect \
+        curl
 
 WORKDIR /app
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,12 +21,14 @@ pipeline {
     stage('Run Job') {
       steps {
         sh 'python3 openlibrary-wikidata-bot/jobs/sync_edition_olids_by_isbns.py'
+        sh 'python3 openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py --sql-path="tbd"'
       }
     }
   }
   post {
     always {
       archiveArtifacts artifacts: 'logs/jobs/sync_edition_olids_by_isbns/*', allowEmptyArchive: true
+      archiveArtifacts artifacts: 'logs/jobs/sync_author_identifiers_from_wikidata.py/*', allowEmptyArchive: true
       deleteDir() // Delete the workspace
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
     stage('sync_author_identifiers_from_wikidata') {
       steps {
         sh '''
-          wget -qO- "https://openlibrary.org/data/ol_dump_wikidata_latest.txt.gz" | zcat > ol_dump_wikidata.tsv
+          curl -sL "https://openlibrary.org/data/ol_dump_wikidata_latest.txt.gz" | zcat > ol_dump_wikidata.tsv
         '''
         sh 'python3 openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py --sql-path="ol_dump_wikidata.tsv"'
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -41,9 +41,8 @@ pipeline {
     } */
     stage('sync_author_identifiers_from_wikidata') {
       steps {
-        // TODO: Update link after https://github.com/internetarchive/openlibrary/pull/10902 deployed
         sh '''
-          curl -sL "https://archive.org/download/ol_dump_2025-05-31/ol_dump_wikidata_2025-05-31.txt.gz" | zcat > ol_dump_wikidata.tsv
+          wget -qO- "https://openlibrary.org/data/ol_dump_wikidata_latest.txt.gz" | zcat > ol_dump_wikidata.tsv
         '''
         sh 'python3 openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py --sql-path="ol_dump_wikidata.tsv"'
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,11 +34,11 @@ pipeline {
         }
       }
     }
-    stage('Run Job') {
+    /* stage('Run Job') {
       steps {
         sh 'python3 openlibrary-wikidata-bot/jobs/sync_edition_olids_by_isbns.py'
       }
-    }
+    } */
     stage('sync_author_identifiers_from_wikidata') {
       steps {
         // TODO: Update link after https://github.com/internetarchive/openlibrary/pull/10902 deployed

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ pipeline {
   post {
     always {
       archiveArtifacts artifacts: 'logs/jobs/sync_edition_olids_by_isbns/*', allowEmptyArchive: true
-      archiveArtifacts artifacts: 'logs/jobs/sync_author_identifiers_from_wikidata.py/*', allowEmptyArchive: true
+      archiveArtifacts artifacts: 'logs/jobs/sync_author_identifiers_from_wikidata/*', allowEmptyArchive: true
       deleteDir() // Delete the workspace
     }
   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,9 +49,8 @@ pipeline {
         expression { params.RUN_SYNC_AUTHOR_IDENTIFIERS_FROM_WIKIDATA }
       }
       steps {
-        // TMP: Limiting to 20 records
         sh '''
-          curl -sL "https://openlibrary.org/data/ol_dump_wikidata_latest.txt.gz" | zcat | head -n20 > ol_dump_wikidata.tsv
+          curl -sL "https://openlibrary.org/data/ol_dump_wikidata_latest.txt.gz" | zcat > ol_dump_wikidata.tsv
         '''
         sh 'python3 openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py --sql-path="ol_dump_wikidata.tsv"'
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -37,7 +37,15 @@ pipeline {
     stage('Run Job') {
       steps {
         sh 'python3 openlibrary-wikidata-bot/jobs/sync_edition_olids_by_isbns.py'
-        sh 'python3 openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py --sql-path="tbd"'
+      }
+    }
+    stage('sync_author_identifiers_from_wikidata') {
+      steps {
+        // TODO: Update link after https://github.com/internetarchive/openlibrary/pull/10902 deployed
+        sh '''
+          curl -sL "https://archive.org/download/ol_dump_2025-05-31/ol_dump_wikidata_2025-05-31.txt.gz" | zcat > ol_dump_wikidata.tsv
+        '''
+        sh 'python3 openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py --sql-path="ol_dump_wikidata.tsv"'
       }
     }
   }

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -190,14 +190,14 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                         write_error(wd_id, ol_id, f"multiple_wikidata_remote_ids_for_one_author", remote_ids_key, ",".join([f'"{val}"' for val in valid_wd_remote_id_values]))
 
                 if len(remote_ids.keys()) > 0:
-                    # TODO: Merge remote IDs with the author's existing remote IDs
-                    # 
-                    # for author in authors:
-                    #   author.remote_ids, matches = merge_remote_ids(remote_ids)
-                    #   if matches > 0:
-                    #     if not dry_run:
-                    #        author.save("[sync_author_identifiers_from_wikidata] add wikidata rekote identifiers")
-                    #     else:
+            # TODO: Merge remote IDs with the author's existing remote IDs
+            # 
+            # 
+            # author.remote_ids, matches = merge_remote_ids(remote_ids)
+            # if matches > 0:
+            #     if not dry_run:
+            #        author.save("[sync_author_identifiers_with_wikidata] add wikidata remote identifiers")
+            #     else:
                     logger.info(f'new remote_ids for [{", ".join(ol_ids)}]: {remote_ids}')
 
             except json.JSONDecodeError as e:

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -166,7 +166,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                         author.name,
                         "multiple_openlibrary_authors_for_one_wikidata_row",
                         "ol_id",
-                        f'[{",".join([f'"{val}"' for val in ol_ids])}]',
+                        json.dumps(ol_ids),
                     )
                 continue
             ol_id = ol_ids[0]
@@ -205,7 +205,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                         author.name,
                         "multiple_wikidata_remote_ids_for_one_author",
                         ol_identifier_name,
-                        f'[{",".join([f'"{val}"' for val in valid_wd_remote_id_values])}]',
+                        json.dumps(valid_wd_remote_id_values),
                     )
 
             if len(remote_ids.keys()) > 0:

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -166,7 +166,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                         author.name,
                         "multiple_openlibrary_authors_for_one_wikidata_row",
                         "ol_id",
-                        " ".join([f'"{val}"' for val in ol_ids]),
+                        " ".join(ol_ids),
                     )
                 continue
             ol_id = ol_ids[0]
@@ -205,7 +205,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                         author.name,
                         "multiple_wikidata_remote_ids_for_one_author",
                         ol_identifier_name,
-                        " ".join([f'"{val}"' for val in valid_wd_remote_id_values]),
+                        " ".join(valid_wd_remote_id_values),
                     )
 
             if len(remote_ids.keys()) > 0:

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -208,10 +208,10 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
 
             remote_ids = merge_remote_ids(author, remote_ids, wd_id)
             if not dry_run:
-                pass
-                # I am not trying this yet! I'm terrified! I made dry-run default to false for this reason 😬
-                # author.remote_ids = remote_ids
-                # author.save("[sync_author_identifiers_with_wikidata] add wikidata remote identifiers")
+                author.remote_ids = remote_ids
+                author.save(
+                    "[sync_author_identifiers_with_wikidata] add wikidata remote identifiers"
+                )
             logger.info(f"new remote_ids for {ol_id}: {remote_ids}")
 
 

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -126,7 +126,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
         next(file)  # skip the header line
         reader = csv.reader(file, delimiter="\t")  # Read as TSV
         for row in reader:
-            assert len(row) == 2
+            assert len(row) == 3
             wikidata_col_raw = row[1]
 
             parsed_wikidata_json = ""

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -33,7 +33,7 @@ logger.addHandler(file_handler)
 
 # Setup error sheet
 n = datetime.datetime.now().strftime("%Y-%m-%d-%H%M%S")
-csv_file_path = f"{problem_dir}/sync_author_wikidata_ids_merge_problems-{n}.csv"
+csv_file_path = f'{problem_dir}/sync_author_wikidata_ids_merge_problems-{n}.csv'
 with open(csv_file_path, mode="w", newline="", encoding="utf-8") as file:
     writer = csv.writer(file)
     writer.writerow(["wdid", "olid", "author_name", "problem", "identifier", "details"])  # Write header
@@ -86,7 +86,7 @@ def merge_remote_ids(
     If incoming_ids is empty, or if there are more conflicts than matches, no merge will be attempted, and the output will be (author.remote_ids, -1).
     """
     if not hasattr(author, "remote_ids"):
-        write_error(wd_id, author.olid, author.name, f"openlibrary_author_remote_ids_failed_to_fetch", "", "")
+        write_error(wd_id, author.olid, author.name, "openlibrary_author_remote_ids_failed_to_fetch", "", "")
         return {}, -1
     output = {**author.remote_ids}
     # Count
@@ -96,9 +96,7 @@ def merge_remote_ids(
         if identifier in output and identifier in incoming_ids:
             if output[identifier] != incoming_ids[identifier]:
                 conflicts = conflicts + 1
-                write_error(wd_id, author.olid, author.name, f"openlibrary_wikidata_remote_id_collision", identifier, f'{{"ol": "{output[identifier]}", "wd": "{incoming_ids[identifier]}"}}')
-            else:
-                output[identifier] = incoming_ids[identifier]
+                write_error(wd_id, author.olid, author.name, "openlibrary_wikidata_remote_id_collision", identifier, f'{{"ol": "{output[identifier]}", "wd": "{incoming_ids[identifier]}"}}')
         elif identifier in incoming_ids and identifier not in output:
             output[identifier] = incoming_ids[identifier]
             update_count = update_count + 1
@@ -146,7 +144,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                 if len(ol_ids) > 1:
                     for ol_id in ol_ids:
                         author = ol.Author.get(ol_id)
-                        write_error(wd_id, ol_id, author.name, f"multiple_openlibrary_authors_for_one_wikidata_row", "ol_id", f'[{",".join([f'"{val}"' for val in ol_ids])}]')
+                        write_error(wd_id, ol_id, author.name, "multiple_openlibrary_authors_for_one_wikidata_row", "ol_id", f'[{",".join([f'"{val}"' for val in ol_ids])}]')
                     continue
                 ol_id = ol_ids[0]
 
@@ -180,7 +178,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                     
                     # Bad case: there are multiple values for the remote ID
                     elif len(wd_remote_id_values) > 1:
-                        write_error(wd_id, ol_id, author.name, f"multiple_wikidata_remote_ids_for_one_author", remote_ids_key, ",".join([f'"{val}"' for val in valid_wd_remote_id_values]))
+                        write_error(wd_id, ol_id, author.name, "multiple_wikidata_remote_ids_for_one_author", remote_ids_key, ",".join([f'"{val}"' for val in valid_wd_remote_id_values]))
 
                 if len(remote_ids.keys()) > 0:
                     remote_ids, update_count = merge_remote_ids(author, remote_ids, wd_id)
@@ -193,7 +191,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                         logger.info(f'new remote_ids for {ol_id}: {remote_ids}')
 
             except json.JSONDecodeError as e:
-                logger.error(f"Error parsing wikidata JSON on row {row} - {e}")
+                logger.error("Error parsing wikidata JSON on row {row} - {e}")
     
             
 if __name__ == "__main__":

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -91,7 +91,6 @@ def merge_remote_ids(author, incoming_ids, wd_id) -> tuple[dict[str, str], int]:
     """
     output = deepcopy(getattr(author, "remote_ids", {}))
     # Count
-    update_count = 0
     conflicts = 0
     for identifier in WD_PID_TO_OL_IDENTIFIER_NAME.values():
         if (
@@ -110,10 +109,9 @@ def merge_remote_ids(author, incoming_ids, wd_id) -> tuple[dict[str, str], int]:
             )
         elif identifier in incoming_ids and identifier not in output:
             output[identifier] = incoming_ids[identifier]
-            update_count = update_count + 1
     if conflicts > 0:
         return author.remote_ids, -1
-    return output, update_count
+    return output
 
 
 def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
@@ -208,7 +206,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                         json.dumps(valid_wd_remote_id_values),
                     )
 
-            remote_ids, update_count = merge_remote_ids(author, remote_ids, wd_id)
+            remote_ids = merge_remote_ids(author, remote_ids, wd_id)
             if not dry_run:
                 pass
                 # I am not trying this yet! I'm terrified! I made dry-run default to false for this reason 😬

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -1,0 +1,220 @@
+from datetime import datetime
+# from olclient import OpenLibrary
+from os import makedirs
+import argparse
+import csv
+import datetime
+import json
+import logging
+import re
+import sys
+
+# Setup logger
+logger = logging.getLogger("jobs.sync_author_wikidata_ids")
+logger.setLevel(logging.DEBUG)
+# The logging format
+log_formatter = logging.Formatter('%(name)s;%(levelname)-8s;%(asctime)s %(message)s')
+# Log warnings+ to console
+console_handler = logging.StreamHandler()
+console_handler.setLevel(logging.WARN)
+console_handler.setFormatter(log_formatter)
+logger.addHandler(console_handler)
+# Log INFO+ to the log file
+log_dir = 'logs/jobs/sync_author_wikidata_ids'
+problem_dir = 'exports/jobs/sync_author_wikidata_ids'
+makedirs(log_dir, exist_ok=True)
+makedirs(problem_dir, exist_ok=True)
+log_file_datetime = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+log_file = log_dir + '/sync_author_wikidata_ids_%s.log' % log_file_datetime
+file_handler = logging.FileHandler(log_file)
+file_handler.setLevel(logging.DEBUG)
+file_handler.setFormatter(log_formatter)
+logger.addHandler(file_handler)
+
+# Setup error sheet
+n = datetime.datetime.now().strftime("%Y-%m-%d-%H%M%S")
+csv_file_path = f"{problem_dir}/sync_author_wikidata_ids_merge_problems-{n}.csv"
+with open(csv_file_path, mode="w", newline="", encoding="utf-8") as file:
+    writer = csv.writer(file)
+    writer.writerow(["wdid", "olid", "problem", "identifier", "details"])  # Write header
+
+# I'd like it if this could come from identifiers.yml, but that's in a totally different repo!
+# In an ideal world, identifiers.yml stores the WD P### identifier for each remote ID type, and we can loop thru that instead.
+# Wikidata JSONs only use the P### identifier, so that's our only way to target specific remote IDs.
+WD_IDENTIFIERS = {
+    "P214": "viaf",
+    "P2607": "bookbrainz",
+    "P434": "musicbrainz",
+    "P2963": "goodreads",
+    "P213": "isni",
+    "P345": "imdb",
+    "P244": "lc_naf",
+    "P7400": "librarything",
+    "P1899": "librivox",
+    "P1938": "project_gutenberg",
+    "P396": "opac_sbn",
+    "P4862": "amazon",
+    "P12430": "storygraph",
+    "P2397": "youtube"
+}
+
+def validate_wikidata_key(obj: dict[str, any], key=str) -> bool:
+    if not("property" in obj):
+         return False
+    if not ("id" in obj["property"]):
+         return False 
+    if key != obj["property"]["id"]:
+         return False
+    if not ("value" in obj):
+        return False
+    if not ("content" in obj["value"]):
+        return False
+    return True
+
+
+def write_error(wd_id, author_key, error_type, id, details):
+    logger.error(f'{error_type} for {author_key}, wd {wd_id}: {id}: {details}')
+    with open(csv_file_path, mode="a", newline="", encoding="utf-8") as file:
+        writer = csv.writer(file)
+        writer.writerow([wd_id, author_key, error_type, id, details])
+
+
+def merge_remote_ids(
+    author, incoming_ids
+) -> tuple[dict[str, str], int]:
+    """Returns the author's remote IDs merged with a given remote IDs object, as well as a count for how many IDs had conflicts.
+    If incoming_ids is empty, or if there are more conflicts than matches, no merge will be attempted, and the output will be (author.remote_ids, -1).
+    """
+    output = {**author.remote_ids}
+    if len(incoming_ids.items()) == 0:
+        return output, -1
+    # Count
+    matches = 0
+    conflicts = 0
+    for identifier in WD_IDENTIFIERS.values():
+        if identifier in output and identifier in incoming_ids:
+            if output[identifier] != incoming_ids[identifier]:
+                conflicts = conflicts + 1
+                write_error(author.key, f"openlibrary_wikidata_remote_id_collision", identifier, f'{{"ol": "{output[identifier]}", "wd": "{incoming_ids[identifier]}"}}')
+            else:
+                output[identifier] = incoming_ids[identifier]
+                matches = matches + 1
+    if conflicts > matches:
+        return author.remote_ids, -1
+    return output, matches
+
+
+def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
+    # ol = OpenLibrary()
+    # Can't get this to run, requirements.txt fails
+    #ERROR: Cannot install -r requirements.txt (line 1), -r requirements.txt (line 2), openlibrary-client and requests==2.11.1 because these package versions have conflicting dependencies.
+    #
+    #The conflict is caused by:
+    #    The user requested requests==2.11.1
+    #    openlibrary-client 0.0.17 depends on requests==2.11.1
+    #    internetarchive 1.7.3 depends on requests<3.0.0 and >=2.9.1
+    #    pywikibot 7.0.0 depends on requests>=2.20.1; python_version >= "3.6"
+
+    csv.field_size_limit(sys.maxsize)
+
+    # Read in the wikidata DB dump
+    with open(sql_path, mode="r", encoding="utf-8") as file:
+        next(file) # skip the header line
+        reader = csv.reader(file, delimiter="\t")  # Read as TSV
+        for row in reader:
+            if len(row) < 2:
+                continue
+            wikidata_col_raw = row[1]
+            
+            try:
+                parsed_wikidata_json = json.loads(wikidata_col_raw)
+                wd_json_top_level_fields = parsed_wikidata_json["statements"]
+
+                # Skip if no OL ID
+                if not ("P648" in wd_json_top_level_fields):
+                    continue
+
+                # Some of these WD entries match multiple OL authors. 
+                # What to do in that scenario?
+                # For now, flagging that as a problem
+
+                ol_ids = [
+                    obj["value"]["content"]
+                    for obj in wd_json_top_level_fields.get("P648", [])
+                    if validate_wikidata_key(obj, "P648") and re.fullmatch(r"OL\d+A", obj["value"]["content"])
+                ]
+
+                if len(ol_ids) == 0:
+                    continue
+                wd_id = parsed_wikidata_json["id"]
+
+                if len(ol_ids) > 1:
+                    for ol_id in ol_ids:
+                        write_error(wd_id, ol_id, f"multiple_openlibrary_authors_for_one_wikidata_row", "ol_id", f'[{",".join([f'"{val}"' for val in ol_ids])}]')
+                    continue
+                ol_id = ol_ids[0]
+
+                # TODO: get authors from OL client when i can get requirements.txt to work
+                # author = ol.Author.get(key=ol_id)
+
+                remote_ids = {}
+
+                # Check for just the identifiers we're interested in
+                for wd_p_value, remote_ids_key in WD_IDENTIFIERS.items():
+
+                    # Skip if this remote ID isn't in the wikidata json at all
+                    if wd_p_value not in wd_json_top_level_fields:
+                        continue
+                    wd_remote_id_values = wd_json_top_level_fields.get(wd_p_value, [])
+                    if len(wd_remote_id_values) == 0:
+                        continue
+
+                    # Get the value(s) for this remote ID from the wikidata json
+                    valid_wd_remote_id_values = [
+                        obj["value"]["content"]
+                        for obj in wd_remote_id_values
+                        if validate_wikidata_key(obj, wd_p_value)
+                    ]
+                    if len(valid_wd_remote_id_values) == 0:
+                        continue
+                    
+                    # Simple case: there's only one match. Add it to the remote_ids dict
+                    if len(valid_wd_remote_id_values) == 1:
+                        remote_id_value = valid_wd_remote_id_values[0]
+                        # print(f"    {remote_ids_key}: {remote_id_value}")
+                        remote_ids[remote_ids_key] = remote_id_value
+                    
+                    # Bad case: there are multiple values for the remote ID
+                    elif len(wd_remote_id_values) > 1:
+                        # print(f"\033[91m    {remote_ids_key}: {", ".join([obj['value']['content'] for obj in wd_remote_id_values])}\033[0m")
+                        write_error(wd_id, ol_id, f"multiple_wikidata_remote_ids_for_one_author", remote_ids_key, ",".join([f'"{val}"' for val in valid_wd_remote_id_values]))
+
+                if len(remote_ids.keys()) > 0:
+                    # TODO: Merge remote IDs with the author's existing remote IDs
+                    # 
+                    # for author in authors:
+                    #   author.remote_ids, matches = merge_remote_ids(remote_ids)
+                    #   if matches > 0:
+                    #     if not dry_run:
+                    #        author.save("[sync_author_identifiers_from_wikidata] add wikidata rekote identifiers")
+                    #     else:
+                    logger.info(f'new remote_ids for [{", ".join(ol_ids)}]: {remote_ids}')
+
+            except json.JSONDecodeError as e:
+                logger.error(f"Error parsing wikidata JSON on row {row} - {e}")
+    
+            
+if __name__ == "__main__":
+    console_handler.setLevel(logging.INFO)
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--dry-run', action='store_true',
+                        help="Don't actually perform edits")
+    parser.add_argument('--sql-path', type=str, required=True,
+                        help='Filepath of the sql dump file to parse')
+    args = parser.parse_args()
+
+    try:
+        consolidate_remote_author_ids(sql_path=args.sql_path, dry_run=args.dry_run)
+    except Exception as e:
+        logger.exception("")
+        raise e

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -208,14 +208,13 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                         json.dumps(valid_wd_remote_id_values),
                     )
 
-            if len(remote_ids.keys()) > 0:
-                remote_ids, update_count = merge_remote_ids(author, remote_ids, wd_id)
-                if not dry_run:
-                    pass
-                    # I am not trying this yet! I'm terrified! I made dry-run default to false for this reason 😬
-                    # author.remote_ids = remote_ids
-                    # author.save("[sync_author_identifiers_with_wikidata] add wikidata remote identifiers")
-                logger.info(f"new remote_ids for {ol_id}: {remote_ids}")
+            remote_ids, update_count = merge_remote_ids(author, remote_ids, wd_id)
+            if not dry_run:
+                pass
+                # I am not trying this yet! I'm terrified! I made dry-run default to false for this reason 😬
+                # author.remote_ids = remote_ids
+                # author.save("[sync_author_identifiers_with_wikidata] add wikidata remote identifiers")
+            logger.info(f"new remote_ids for {ol_id}: {remote_ids}")
 
 
 if __name__ == "__main__":

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -99,7 +99,7 @@ def merge_remote_ids(
             else:
                 output[identifier] = incoming_ids[identifier]
                 matches = matches + 1
-    if conflicts > matches:
+    if conflicts > 0:
         return author.remote_ids, -1
     return output, matches
 

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -166,7 +166,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                         author.name,
                         "multiple_openlibrary_authors_for_one_wikidata_row",
                         "ol_id",
-                        f'[{",".join([f'"{val}"' for val in ol_ids])}]',
+                        " ".join([f'"{val}"' for val in ol_ids]),
                     )
                 continue
             ol_id = ol_ids[0]
@@ -205,7 +205,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                         author.name,
                         "multiple_wikidata_remote_ids_for_one_author",
                         ol_identifier_name,
-                        ",".join([f'"{val}"' for val in valid_wd_remote_id_values]),
+                        " ".join([f'"{val}"' for val in valid_wd_remote_id_values]),
                     )
 
             if len(remote_ids.keys()) > 0:

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from datetime import datetime
 from olclient import OpenLibrary
 from os import makedirs
@@ -13,19 +14,20 @@ import sys
 logger = logging.getLogger("jobs.sync_author_wikidata_ids")
 logger.setLevel(logging.DEBUG)
 # The logging format
-log_formatter = logging.Formatter('%(name)s;%(levelname)-8s;%(asctime)s %(message)s')
+log_formatter = logging.Formatter("%(name)s;%(levelname)-8s;%(asctime)s %(message)s")
 # Log warnings+ to console
 console_handler = logging.StreamHandler()
 console_handler.setLevel(logging.WARN)
 console_handler.setFormatter(log_formatter)
 logger.addHandler(console_handler)
 # Log INFO+ to the log file
-log_dir = 'logs/jobs/sync_author_wikidata_ids'
-problem_dir = 'exports/jobs/sync_author_wikidata_ids'
+log_dir = "logs/jobs/sync_author_wikidata_ids"
 makedirs(log_dir, exist_ok=True)
-makedirs(problem_dir, exist_ok=True)
 log_file_datetime = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-log_file = log_dir + '/sync_author_wikidata_ids_%s.log' % log_file_datetime
+log_file = log_dir + "/sync_author_wikidata_ids_%s.log" % log_file_datetime
+problems_file = (
+    log_dir + "/sync_author_wikidata_ids_%s_problems.csv" % log_file_datetime
+)
 file_handler = logging.FileHandler(log_file)
 file_handler.setLevel(logging.DEBUG)
 file_handler.setFormatter(log_formatter)
@@ -33,15 +35,16 @@ logger.addHandler(file_handler)
 
 # Setup error sheet
 n = datetime.datetime.now().strftime("%Y-%m-%d-%H%M%S")
-csv_file_path = f'{problem_dir}/sync_author_wikidata_ids_merge_problems-{n}.csv'
-with open(csv_file_path, mode="w", newline="", encoding="utf-8") as file:
+with open(problems_file, mode="w", newline="", encoding="utf-8") as file:
     writer = csv.writer(file)
-    writer.writerow(["wdid", "olid", "author_name", "problem", "identifier", "details"])  # Write header
+    writer.writerow(
+        ["wdid", "olid", "author_name", "problem", "identifier", "details"]
+    )  # Write header
 
 # I'd like it if this could come from identifiers.yml, but that's in a totally different repo!
 # In an ideal world, identifiers.yml stores the WD P### identifier for each remote ID type, and we can loop thru that instead.
 # Wikidata JSONs only use the P### identifier, so that's our only way to target specific remote IDs.
-WD_IDENTIFIERS = {
+WD_PID_TO_OL_IDENTIFIER_NAME = {
     "P214": "viaf",
     "P2607": "bookbrainz",
     "P434": "musicbrainz",
@@ -55,16 +58,17 @@ WD_IDENTIFIERS = {
     "P396": "opac_sbn",
     "P4862": "amazon",
     "P12430": "storygraph",
-    "P2397": "youtube"
+    "P2397": "youtube",
 }
 
+
 def validate_wikidata_key(obj: dict[str, any], key=str) -> bool:
-    if not("property" in obj):
-         return False
+    if not ("property" in obj):
+        return False
     if not ("id" in obj["property"]):
-         return False 
+        return False
     if key != obj["property"]["id"]:
-         return False
+        return False
     if not ("value" in obj):
         return False
     if not ("content" in obj["value"]):
@@ -73,30 +77,37 @@ def validate_wikidata_key(obj: dict[str, any], key=str) -> bool:
 
 
 def write_error(wd_id, author_key, author_name, error_type, id, details):
-    logger.error(f'{error_type} for {author_key} ({author_name}), wd {wd_id}: {id}: {details}')
-    with open(csv_file_path, mode="a", newline="", encoding="utf-8") as file:
+    logger.error(
+        f"{error_type} for {author_key} ({author_name}), wd {wd_id}: {id}: {details}"
+    )
+    with open(problems_file, mode="a", newline="", encoding="utf-8") as file:
         writer = csv.writer(file)
         writer.writerow([wd_id, author_key, author_name, error_type, id, details])
 
 
-def merge_remote_ids(
-    author, incoming_ids, wd_id
-) -> tuple[dict[str, str], int]:
+def merge_remote_ids(author, incoming_ids, wd_id) -> tuple[dict[str, str], int]:
     """Returns the author's remote IDs merged with a given remote IDs object, as well as a count for how many IDs had conflicts.
     If incoming_ids is empty, or if there are more conflicts than matches, no merge will be attempted, and the output will be (author.remote_ids, -1).
     """
-    if not hasattr(author, "remote_ids"):
-        write_error(wd_id, author.olid, author.name, "openlibrary_author_remote_ids_failed_to_fetch", "", "")
-        return {}, -1
-    output = {**author.remote_ids}
+    output = deepcopy(getattr(author, "remote_ids", {}))
     # Count
     update_count = 0
     conflicts = 0
-    for identifier in WD_IDENTIFIERS.values():
-        if identifier in output and identifier in incoming_ids:
-            if output[identifier] != incoming_ids[identifier]:
-                conflicts = conflicts + 1
-                write_error(wd_id, author.olid, author.name, "openlibrary_wikidata_remote_id_collision", identifier, f'{{"ol": "{output[identifier]}", "wd": "{incoming_ids[identifier]}"}}')
+    for identifier in WD_PID_TO_OL_IDENTIFIER_NAME.values():
+        if (
+            identifier in output
+            and identifier in incoming_ids
+            and output[identifier] != incoming_ids[identifier]
+        ):
+            conflicts = conflicts + 1
+            write_error(
+                wd_id,
+                author.olid,
+                author.name,
+                "openlibrary_wikidata_remote_id_collision",
+                identifier,
+                f'{{"ol": "{output[identifier]}", "wd": "{incoming_ids[identifier]}"}}',
+            )
         elif identifier in incoming_ids and identifier not in output:
             output[identifier] = incoming_ids[identifier]
             update_count = update_count + 1
@@ -112,95 +123,113 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
 
     # Read in the wikidata DB dump
     with open(sql_path, mode="r", encoding="utf-8") as file:
-        next(file) # skip the header line
+        next(file)  # skip the header line
         reader = csv.reader(file, delimiter="\t")  # Read as TSV
         for row in reader:
-            if len(row) < 2:
-                continue
+            assert len(row) == 2
             wikidata_col_raw = row[1]
-            
+
+            parsed_wikidata_json = ""
+
             try:
                 parsed_wikidata_json = json.loads(wikidata_col_raw)
-                wd_json_top_level_fields = parsed_wikidata_json["statements"]
-
-                # Skip if no OL ID
-                if not ("P648" in wd_json_top_level_fields):
-                    continue
-
-                # Some of these WD entries match multiple OL authors. 
-                # What to do in that scenario?
-                # For now, flagging that as a problem
-
-                ol_ids = [
-                    obj["value"]["content"]
-                    for obj in wd_json_top_level_fields.get("P648", [])
-                    if validate_wikidata_key(obj, "P648") and re.fullmatch(r"OL\d+A", obj["value"]["content"])
-                ]
-
-                if len(ol_ids) == 0:
-                    continue
-                wd_id = parsed_wikidata_json["id"]
-
-                if len(ol_ids) > 1:
-                    for ol_id in ol_ids:
-                        author = ol.Author.get(ol_id)
-                        write_error(wd_id, ol_id, author.name, "multiple_openlibrary_authors_for_one_wikidata_row", "ol_id", f'[{",".join([f'"{val}"' for val in ol_ids])}]')
-                    continue
-                ol_id = ol_ids[0]
-
-                author = ol.Author.get(ol_id)
-
-                remote_ids = {}
-
-                # Check for just the identifiers we're interested in
-                for wd_p_value, remote_ids_key in WD_IDENTIFIERS.items():
-
-                    # Skip if this remote ID isn't in the wikidata json at all
-                    if wd_p_value not in wd_json_top_level_fields:
-                        continue
-                    wd_remote_id_values = wd_json_top_level_fields.get(wd_p_value, [])
-                    if len(wd_remote_id_values) == 0:
-                        continue
-
-                    # Get the value(s) for this remote ID from the wikidata json
-                    valid_wd_remote_id_values = [
-                        obj["value"]["content"]
-                        for obj in wd_remote_id_values
-                        if validate_wikidata_key(obj, wd_p_value)
-                    ]
-                    if len(valid_wd_remote_id_values) == 0:
-                        continue
-                    
-                    # Simple case: there's only one match. Add it to the remote_ids dict
-                    if len(valid_wd_remote_id_values) == 1:
-                        remote_id_value = valid_wd_remote_id_values[0]
-                        remote_ids[remote_ids_key] = remote_id_value
-                    
-                    # Bad case: there are multiple values for the remote ID
-                    elif len(wd_remote_id_values) > 1:
-                        write_error(wd_id, ol_id, author.name, "multiple_wikidata_remote_ids_for_one_author", remote_ids_key, ",".join([f'"{val}"' for val in valid_wd_remote_id_values]))
-
-                if len(remote_ids.keys()) > 0:
-                    remote_ids, update_count = merge_remote_ids(author, remote_ids, wd_id)
-                    if update_count > 0:
-                        if not dry_run:
-                            pass
-                            # I am not trying this yet! I'm terrified! I made dry-run default to false for this reason 😬
-                            # author.remote_ids = remote_ids
-                            # author.save("[sync_author_identifiers_with_wikidata] add wikidata remote identifiers")
-                        logger.info(f'new remote_ids for {ol_id}: {remote_ids}')
-
             except json.JSONDecodeError as e:
                 logger.error("Error parsing wikidata JSON on row {row} - {e}")
-    
-            
+                continue
+            wd_statements = parsed_wikidata_json["statements"]
+
+            # Skip if no OL ID
+            if not ("P648" in wd_statements):
+                continue
+
+            # Some of these WD entries match multiple OL authors.
+            # What to do in that scenario?
+            # For now, flagging that as a problem
+
+            ol_ids = [
+                obj["value"]["content"]
+                for obj in wd_statements.get("P648", [])
+                if validate_wikidata_key(obj, "P648")
+                and re.fullmatch(r"OL\d+A", obj["value"]["content"])
+            ]
+
+            if len(ol_ids) == 0:
+                continue
+            wd_id = parsed_wikidata_json["id"]
+
+            if len(ol_ids) > 1:
+                for ol_id in ol_ids:
+                    author = ol.Author.get(ol_id)
+                    write_error(
+                        wd_id,
+                        ol_id,
+                        author.name,
+                        "multiple_openlibrary_authors_for_one_wikidata_row",
+                        "ol_id",
+                        f'[{",".join([f'"{val}"' for val in ol_ids])}]',
+                    )
+                continue
+            ol_id = ol_ids[0]
+
+            author = ol.Author.get(ol_id)
+
+            remote_ids = {"wikidata": wd_id}
+
+            # Check for just the identifiers we're interested in
+            for pid, ol_identifier_name in WD_PID_TO_OL_IDENTIFIER_NAME.items():
+
+                # Skip if this remote ID isn't in the wikidata json at all
+                wd_remote_id_values = wd_statements.get(pid, [])
+                if len(wd_remote_id_values) == 0:
+                    continue
+
+                # Get the value(s) for this remote ID from the wikidata json
+                valid_wd_remote_id_values = [
+                    obj["value"]["content"]
+                    for obj in wd_remote_id_values
+                    if validate_wikidata_key(obj, pid)
+                ]
+                if len(valid_wd_remote_id_values) == 0:
+                    continue
+
+                # Simple case: there's only one match. Add it to the remote_ids dict
+                elif len(valid_wd_remote_id_values) == 1:
+                    remote_id_value = valid_wd_remote_id_values[0]
+                    remote_ids[ol_identifier_name] = remote_id_value
+
+                # Bad case: there are multiple values for the remote ID
+                else:
+                    write_error(
+                        wd_id,
+                        ol_id,
+                        author.name,
+                        "multiple_wikidata_remote_ids_for_one_author",
+                        ol_identifier_name,
+                        ",".join([f'"{val}"' for val in valid_wd_remote_id_values]),
+                    )
+
+            if len(remote_ids.keys()) > 0:
+                remote_ids, update_count = merge_remote_ids(author, remote_ids, wd_id)
+                if not dry_run:
+                    pass
+                    # I am not trying this yet! I'm terrified! I made dry-run default to false for this reason 😬
+                    # author.remote_ids = remote_ids
+                    # author.save("[sync_author_identifiers_with_wikidata] add wikidata remote identifiers")
+                logger.info(f"new remote_ids for {ol_id}: {remote_ids}")
+
+
 if __name__ == "__main__":
     console_handler.setLevel(logging.INFO)
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--dry-run', action='store_true',
-                        help="Don't actually perform edits")
-    parser.add_argument('--sql-path', type=str, required=True,
-                        help='Filepath of the sql dump file to parse')
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Don't actually perform edits"
+    )
+    parser.add_argument(
+        "--sql-path",
+        type=str,
+        required=True,
+        help="Filepath of the sql dump file to parse",
+    )
     args = parser.parse_args()
 
     try:

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -198,7 +198,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
             #     if not dry_run:
             #        author.save("[sync_author_identifiers_with_wikidata] add wikidata remote identifiers")
             #     else:
-                    logger.info(f'new remote_ids for [{", ".join(ol_ids)}]: {remote_ids}')
+                    logger.info(f'new remote_ids for {ol_id}: {remote_ids}')
 
             except json.JSONDecodeError as e:
                 logger.error(f"Error parsing wikidata JSON on row {row} - {e}")

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -166,7 +166,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                         author.name,
                         "multiple_openlibrary_authors_for_one_wikidata_row",
                         "ol_id",
-                        " ".join(ol_ids),
+                        f'[{",".join([f'"{val}"' for val in ol_ids])}]',
                     )
                 continue
             ol_id = ol_ids[0]
@@ -205,7 +205,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                         author.name,
                         "multiple_wikidata_remote_ids_for_one_author",
                         ol_identifier_name,
-                        " ".join(valid_wd_remote_id_values),
+                        f'[{",".join([f'"{val}"' for val in valid_wd_remote_id_values])}]',
                     )
 
             if len(remote_ids.keys()) > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
--e git+https://github.com/internetarchive/openlibrary-client.git@2fd63727ef13f5443fc489ca9d71d3b224485c27#egg=openlibrary-client
+-e git+https://github.com/internetarchive/openlibrary-client.git@7e45d512d031970d2bf4f56ca23f6247f205a0a8#egg=openlibrary-client
 -e git+https://github.com/wikimedia/pywikibot-core.git@7.0.0#egg=pywikibot
 # pywikibot deps
 wikitextparser>=0.47.5
 #pywikibot wants requests>=2.20.1, but our version of OL wants
-requests==2.11.1
+requests==2.31.0


### PR DESCRIPTION
Closes https://github.com/internetarchive/openlibrary/issues/10904

- loops through wikidata jsons in a db dump
- wikidata jsons include OL IDs. Get author for that OL ID
- compare the author's existing remote ids to those in the wikidata json being evaluated
- happy path: wikidata json has 0 to 1 entries per identifier, no wikidata identifiers conflict with existing author remote_ids. save consolidated identifiers to author
- log problems to a CSV to flag to librarians. this includes the following scenarios:
  - the WD json has 2+ values for one identifier
  - the author and the WD json have different values for the same identifier

Sample standard log output:
```
jobs.sync_author_wikidata_ids;ERROR   ;2025-02-11 14:00:07,642 multiple_wikidata_remote_ids_for_one_author for OL41455A (Cathy Hapka), wd Q47111607: viaf: "2550149198364674940004","307206543","371154381055130292167","287124513"
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:07,643 new remote_ids for OL41455A: {'viaf': '2550149198364674940004', 'wikidata': 'Q47111607', 'isni': '0000000071434974', 'lc_naf': 'n98006558'}
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:07,803 new remote_ids for OL1003081A: {'viaf': '56704724', 'wikidata': 'Q55849686', 'isni': '000000011063980X', 'lc_naf': 'n87895285'}
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:07,906 new remote_ids for OL2993169A: {'wikidata': 'Q11496525', 'viaf': '24146805', 'musicbrainz': '04bc5756-d8f6-4dce-9b69-031aefbfd809', 'isni': '0000000043157340', 'lc_naf': 'no00070277'}
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:08,017 new remote_ids for OL1012737A: {'viaf': '68025823', 'wikidata': 'Q20768012', 'isni': '0000000027584422', 'lc_naf': 'n88177720'}
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:08,172 new remote_ids for OL1011626A: {'viaf': '70239270', 'wikidata': 'Q11696284', 'isni': '000000007148842X', 'lc_naf': 'n80151042'}
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:08,386 new remote_ids for OL6849072A: {'viaf': '32004876', 'wikidata': 'Q71243', 'isni': '0000000110236672', 'musicbrainz': 'c30d11c2-d5ac-4d57-8602-75070894f15c', 'imdb': 'nm0000022', 'lc_naf': 'n50015429', 'librarything': 'gableclark'}
jobs.sync_author_wikidata_ids;ERROR   ;2025-02-11 14:00:08,495 multiple_openlibrary_authors_for_one_wikidata_row for OL1006888A (Coolidge, Julian Lowell), wd Q1711970: ol_id: ["OL1006888A","OL6428119A"]
jobs.sync_author_wikidata_ids;ERROR   ;2025-02-11 14:00:08,602 multiple_openlibrary_authors_for_one_wikidata_row for OL6428119A (JulianLowell Coolidge), wd Q1711970: ol_id: ["OL1006888A","OL6428119A"]
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:08,718 new remote_ids for OL20680A: {'viaf': '110866419', 'wikidata': 'Q266959', 'isni': '0000000114551290', 'bookbrainz': 'dd6fbeb9-9d60-4c7d-8258-60f6eaf38107', 'musicbrainz': 'dff258e4-afee-4afc-bdcb-a7da4905e61e', 'imdb': 'nm0874294', 'lc_naf': 'n50011726', 'librarything': 'trumanmargaret'}
jobs.sync_author_wikidata_ids;ERROR   ;2025-02-11 14:00:08,825 openlibrary_author_remote_ids_failed_to_fetch for OL6829207A (), wd Q106465: : 
jobs.sync_author_wikidata_ids;ERROR   ;2025-02-11 14:00:08,940 multiple_openlibrary_authors_for_one_wikidata_row for OL2623297A (), wd Q35610: ol_id: ["OL2623297A","OL161167A"]
jobs.sync_author_wikidata_ids;ERROR   ;2025-02-11 14:00:09,059 multiple_openlibrary_authors_for_one_wikidata_row for OL161167A (Arthur Conan Doyle), wd Q35610: ol_id: ["OL2623297A","OL161167A"]
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:09,183 new remote_ids for OL1009852A: {'viaf': '5084395', 'wikidata': 'Q76355745', 'isni': '0000000063084695', 'lc_naf': 'nr93002240'}
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:09,298 new remote_ids for OL1011980A: {'viaf': '79406089', 'wikidata': 'Q6261280', 'isni': '0000000078611566', 'goodreads': '992059', 'lc_naf': 'n85144834'}
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:09,414 new remote_ids for OL1016513A: {'viaf': '66621585', 'wikidata': 'Q17352048', 'isni': '0000000109110239', 'lc_naf': 'n88258373', 'opac_sbn': 'CFIV076155'}
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:09,524 new remote_ids for OL1012439A: {'viaf': '24728436', 'wikidata': 'Q70833', 'isni': '0000000110466240', 'lc_naf': 'n78082179'}
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:09,652 new remote_ids for OL1011813A: {'wikidata': 'Q366162', 'goodreads': '1579', 'viaf': '29852493', 'musicbrainz': '59b849fe-a22c-477d-a1af-022239282a26', 'isni': '000000036888970X', 'imdb': 'nm0516032', 'lc_naf': 'n85033505'}
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:10,088 new remote_ids for OL1016469A: {'viaf': '71521337', 'wikidata': 'Q214778', 'isni': '0000000109142476', 'lc_naf': 'n84186752'}
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:10,208 new remote_ids for OL1020184A: {'viaf': '9911421', 'wikidata': 'Q2864984', 'isni': '0000000039974209', 'lc_naf': 'n89615669'}
jobs.sync_author_wikidata_ids;INFO    ;2025-02-11 14:00:10,315 new remote_ids for OL1020907A: {'viaf': '52550876', 'wikidata': 'Q29572076', 'isni': '0000000029206046', 'lc_naf': 'n90667626'}
jobs.sync_author_wikidata_ids;ERROR   ;2025-02-11 14:00:10,422 openlibrary_wikidata_remote_id_collision for OL896513A (Justin Cronin), wd Q153701: viaf: {"ol": "44524499", "wd": "305869306"}
jobs.sync_author_wikidata_ids;ERROR   ;2025-02-11 14:00:10,555 openlibrary_author_remote_ids_failed_to_fetch for OL4278498A (), wd Q384651: : 
```

Sample error log output (csv format for us/librarians to use to look into issues):
```
Q47111607,OL41455A,Cathy Hapka,multiple_wikidata_remote_ids_for_one_author,viaf,"""2550149198364674940004"",""307206543"",""371154381055130292167"",""287124513"""
Q1711970,OL1006888A,"Coolidge, Julian Lowell",multiple_openlibrary_authors_for_one_wikidata_row,ol_id,"[""OL1006888A"",""OL6428119A""]"
Q1711970,OL6428119A,JulianLowell Coolidge,multiple_openlibrary_authors_for_one_wikidata_row,ol_id,"[""OL1006888A"",""OL6428119A""]"
Q106465,OL6829207A,,openlibrary_author_remote_ids_failed_to_fetch,,
Q35610,OL2623297A,,multiple_openlibrary_authors_for_one_wikidata_row,ol_id,"[""OL2623297A"",""OL161167A""]"
Q35610,OL161167A,Arthur Conan Doyle,multiple_openlibrary_authors_for_one_wikidata_row,ol_id,"[""OL2623297A"",""OL161167A""]"
Q153701,OL896513A,Justin Cronin,openlibrary_wikidata_remote_id_collision,viaf,"{""ol"": ""44524499"", ""wd"": ""305869306""}"
Q384651,OL4278498A,,openlibrary_author_remote_ids_failed_to_fetch,,
```

Something kind of sketchy is that `inventaire` isn't included in the author's remote ids when fetched. I remember this also being the only ID I couldn't get from wikidata. I think this is just because for most authors, their WD ID will be used as an inventaire ID if they don't have an inventaire ID, and I just haven't come across any that have one purposefully set.