### PR TITLE
fix: account for redirects when updating author wikidata

### DIFF
--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -229,9 +229,9 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
             remote_ids, conflicts = merge_remote_ids(author, remote_ids, wd_id)
             if not dry_run and not conflicts:
                 author.remote_ids = remote_ids
-                # author.save(
-                #     "[sync_author_identifiers_with_wikidata] add wikidata remote identifiers"
-                # )
+                author.save(
+                    "[sync_author_identifiers_with_wikidata] add wikidata remote identifiers"
+                )
             logger.info(f"new remote_ids for {author.olid}: {remote_ids}")
 
 

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -115,8 +115,6 @@ def merge_remote_ids(author, incoming_ids, wd_id) -> tuple[dict[str, str], int]:
     return output, conflicts
 
 
-
-
 def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
     ol = OpenLibrary()
     
@@ -186,9 +184,6 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
             # all results are redirects or no authors found: don't change anything
             if len(authors) == 0:
                 continue
-
-            # PROBLEM: need recursive processing, redirects can be nested
-            # do some kind of recursive that aborts if it sees the same id twice
 
             if len(authors) > 1:
                 for author in authors:

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -115,8 +115,25 @@ def merge_remote_ids(author, incoming_ids, wd_id) -> tuple[dict[str, str], int]:
     return output, conflicts
 
 
+
+
 def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
     ol = OpenLibrary()
+    
+    def resolve_redirects(author, seen=None):
+        if seen is None:
+            seen = set()
+        key = author.olid
+        if not key or key in seen:
+            return []
+        seen.add(key)
+        if author.type.get("key") != "/type/redirect":
+            return [author]
+        location = author.location
+        if location and location.startswith("/authors/"):
+            redirected_author = ol.Author.get(location.split("/authors/")[-1])
+            return resolve_redirects(redirected_author, seen)
+        return []
 
     csv.field_size_limit(sys.maxsize)
 
@@ -157,13 +174,10 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
             wd_id = parsed_wikidata_json["id"]
 
             base_authors = [ol.Author.get(ol_id) for ol_id in ol_ids]
-            redirected_authors = [
-                ol.Author.get(a.location.split("/authors/")[-1])
-                for a in base_authors
-                if a.type.get("key") == "/type/redirect"
-                and getattr(a, "location", None)
-                and a.location.startswith("/authors/")
-            ]
+
+            redirected_authors = []
+            for a in base_authors:
+                redirected_authors.extend(resolve_redirects(a))
             nonredirected_authors = [a for a in base_authors if a.type.get("key") == "/type/author"]
 
             concat_authors = redirected_authors + nonredirected_authors

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -168,9 +168,13 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                         json.dumps(ol_ids),
                     )
                 continue
-            ol_id = ol_ids[0]
+                
+            authors = [ol.Author.get(ol_id) for ol_id in ol_ids]
+            author = next((a for a in authors if a.type.key == "/type/author"), None)
 
-            author = ol.Author.get(ol_id)
+            # all results are redirects or no authors found: don't change anything
+            if author is None:
+                continue
 
             remote_ids = {"wikidata": wd_id}
 

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -156,25 +156,40 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                 continue
             wd_id = parsed_wikidata_json["id"]
 
-            if len(ol_ids) > 1:
-                for ol_id in ol_ids:
-                    author = ol.Author.get(ol_id)
+            base_authors = [ol.Author.get(ol_id) for ol_id in ol_ids]
+            redirected_authors = [
+                ol.Author.get(a.location.split("/authors/")[-1])
+                for a in base_authors
+                if a.type.get("key") == "/type/redirect"
+                and getattr(a, "location", None)
+                and a.location.startswith("/authors/")
+            ]
+            nonredirected_authors = [a for a in base_authors if a.type.get("key") == "/type/author"]
+
+            concat_authors = redirected_authors + nonredirected_authors
+            authors = list({a.olid: a for a in concat_authors}.values()) # unique
+
+            # all results are redirects or no authors found: don't change anything
+            if len(authors) == 0:
+                continue
+
+            # PROBLEM: need recursive processing, redirects can be nested
+            # do some kind of recursive that aborts if it sees the same id twice
+
+            if len(authors) > 1:
+                for author in authors:
                     write_error(
                         wd_id,
-                        ol_id,
+                        author.olid,
                         author.name,
                         "multiple_openlibrary_authors_for_one_wikidata_row",
                         "ol_id",
-                        json.dumps(ol_ids),
+                        json.dumps([author.olid for author in authors]),
                     )
                 continue
-                
-            authors = [ol.Author.get(ol_id) for ol_id in ol_ids]
-            author = next((a for a in authors if a.type.key == "/type/author"), None)
 
-            # all results are redirects or no authors found: don't change anything
-            if author is None:
-                continue
+            # proceed with the first author in the array by default. we've logged extras to investigate later
+            author = authors[0]
 
             remote_ids = {"wikidata": wd_id}
 
@@ -204,7 +219,7 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
                 else:
                     write_error(
                         wd_id,
-                        ol_id,
+                        author.olid,
                         author.name,
                         "multiple_wikidata_remote_ids_for_one_author",
                         ol_identifier_name,
@@ -214,10 +229,10 @@ def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
             remote_ids, conflicts = merge_remote_ids(author, remote_ids, wd_id)
             if not dry_run and not conflicts:
                 author.remote_ids = remote_ids
-                author.save(
-                    "[sync_author_identifiers_with_wikidata] add wikidata remote identifiers"
-                )
-            logger.info(f"new remote_ids for {ol_id}: {remote_ids}")
+                # author.save(
+                #     "[sync_author_identifiers_with_wikidata] add wikidata remote identifiers"
+                # )
+            logger.info(f"new remote_ids for {author.olid}: {remote_ids}")
 
 
 if __name__ == "__main__":

--- a/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
+++ b/openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py
@@ -118,6 +118,7 @@ def merge_remote_ids(author, incoming_ids, wd_id) -> tuple[dict[str, str], int]:
 def consolidate_remote_author_ids(sql_path: str, dry_run: bool = True) -> None:
     ol = OpenLibrary()
     
+    # Follow author redirects until it either hits an object of /type/author or is determined to be an infinite loop redirect.
     def resolve_redirects(author, seen=None):
         if seen is None:
             seen = set()


### PR DESCRIPTION
If wikidata has several OLIDs for an author, check first to see how many of them are actually base author objects and not redirects.

Example: Wikidata item Q15556371's P648 (OL ID) value has three entries. From our DB dump:

```
{
  "id": "Q15556371",
  ...
  "statements": {
    "P648": [
      {
        "id": "Q15556371$242AE70B-A829-4A38-A4BB-7009FB3310D9",
        "rank": "normal",
        "qualifiers": [],
        "references": [],
        "property": {
          "id": "P648",
          "data_type": "external-id"
        },
        "value": {
          "type": "value",
          "content": "OL6980048A"
        }
      },
      {
        "id": "Q15556371$536939B0-404B-41F3-86C5-CF0EC8470F34",
        "rank": "normal",
        "qualifiers": [],
        "references": [],
        "property": {
          "id": "P648",
          "data_type": "external-id"
        },
        "value": {
          "type": "value",
          "content": "OL5384529A"
        }
      },
      {
        "id": "Q15556371$97767E15-6A8D-43EE-BBE2-1F25D7588CD6",
        "rank": "normal",
        "qualifiers": [],
        "references": [],
        "property": {
          "id": "P648",
          "data_type": "external-id"
        },
        "value": {
          "type": "value",
          "content": "OL2528198A"
        }
      }
    ],
  },
  ...
}
```

This updated script looks at the three OLIDs: `['OL6980048A', 'OL5384529A', 'OL2528198A']`
It detects that the first two are /type/redirect and follows their redirect location, which results in the following OLIDs:
`['OL2528198A', 'OL2528198A', 'OL2528198A']`
It then is able to detect that these are all the same author and eliminates duplicates.
It then proceeds to just try to update the author with OLID OL2528198A, which is a real author object and not a redirect.

This also means that, even though this WD item had three author OLIDs, it will no longer log this as a `multiple_openlibrary_authors_for_one_wikidata_row` error since they all resolve to the same one author.

Tested:
`python  openlibrary-wikidata-bot/jobs/sync_author_identifiers_from_wikidata.py --sql-path="ol_dump_wikidata.tsv" ` (ol_dump_wikidata.tsv is the latest from https://openlibrary.org/developers/dumps, also commented out the line that saves the edits while testing)